### PR TITLE
Fix deletion of records

### DIFF
--- a/octodns_transip/__init__.py
+++ b/octodns_transip/__init__.py
@@ -256,7 +256,7 @@ class TransipProvider(BaseProvider):
         for change in changes:
             record = change.new
 
-            if record.name == '' and record._type == 'NS':
+            if record and record.name == '' and record._type == 'NS':
                 values = record.values
 
                 nameservers = []


### PR DESCRIPTION
Deletion of records results in a stack trace in version 0.0.2.

### Example

Create a record in TransIP's controlpanel, and try to remove it with `octodns`:
```
TRANSIP_ACCOUNT='<redacted>' TRANSIP_KEY=".transip.key" octodns-sync --config=config.yaml --doit
...
2024-11-14T10:59:48  [8331819072] INFO  Plan 
********************************************************************************
* <domain>.
********************************************************************************
* transip (TransipProvider)
*   Delete <ARecord A 86400, removeme.<domain>., ['10.10.10.10']>
*   Summary: Creates=0, Updates=0, Deletes=1, Existing Records=5
********************************************************************************


2024-11-14T10:59:48  [8331819072] INFO  TransipProvider[transip] apply: making 1 changes to <domain>.com.
Traceback (most recent call last):
  File "/Users/gerard/github/octodns/env/bin/octodns-sync", line 8, in <module>
    sys.exit(main())
  File "/Users/gerard/github/octodns/env/lib/python3.9/site-packages/octodns/cmds/sync.py", line 62, in main
    manager.sync(
  File "/Users/gerard/github/octodns/env/lib/python3.9/site-packages/octodns/manager.py", line 856, in sync
    total_changes += target.apply(plan)
  File "/Users/gerard/github/octodns/env/lib/python3.9/site-packages/octodns/provider/base.py", line 298, in apply
    self._apply(plan)
  File "/Users/gerard/github/octodns/env/lib/python3.9/site-packages/octodns_transip/__init__.py", line 259, in _apply
    if record.name == '' and record._type == 'NS':
AttributeError: 'NoneType' object has no attribute 'name'
```

I think the AttributeError is caused by `record` being `None` when removing records, because there is no new record with modified values in that case.

### Fix

The fix seems to be to check if `record` is not `None` before checking its `name` and `type` in `_apply`. After adding that deletion works fine:
```
TRANSIP_ACCOUNT='<redacted>' TRANSIP_KEY=".transip.key" octodns-sync --config=config.yaml --doit
...
2024-11-14T11:10:14  [8331819072] INFO  Plan 
********************************************************************************
* <domain>.
********************************************************************************
* transip (TransipProvider)
*   Delete <ARecord A 86400, removeme.<domain>., ['10.10.10.10']>
*   Summary: Creates=0, Updates=0, Deletes=1, Existing Records=5
********************************************************************************


2024-11-14T11:10:14  [8331819072] INFO  TransipProvider[transip] apply: making 1 changes to <domain>.
2024-11-14T11:10:16  [8331819072] INFO  Manager sync:   1 total changes
```
