### PR TITLE
Release 0.0.3 version bump and changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.0.3 - 2024-11-29 - Delete w/o fail
+
+* Deletion of records results in a stack trace in version 0.0.2.
+
 ## v0.0.2 - 2024-10-17 - More the merrier
 
 #### Nothworthy Changes

--- a/octodns_transip/__init__.py
+++ b/octodns_transip/__init__.py
@@ -16,7 +16,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Record
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.2'
+__version__ = __VERSION__ = '0.0.3'
 
 DNSEntry = namedtuple('DNSEntry', ('name', 'expire', 'type', 'content'))
 


### PR DESCRIPTION
## v0.0.3 - 2024-11-29 - Delete w/o fail

* Deletion of records results in a stack trace in version 0.0.2.

/cc Fixes https://github.com/octodns/octodns-transip/issues/46