### PR TITLE
feat(config): Allow passing through global_key option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.4 - 2024-??-?? - ???
+
+* Add global_key provider param to support disabling IP whitelisting
+
+
 ## v0.0.3 - 2024-11-29 - Delete w/o fail
 
 * Deletion of records results in a stack trace in version 0.0.2.

--- a/octodns_transip/__init__.py
+++ b/octodns_transip/__init__.py
@@ -80,15 +80,28 @@ class TransipProvider(BaseProvider):
     # See root NS handling in _process_desired_zone for more information
     ROOT_NS_TTL = 3600
 
-    def __init__(self, id, account, key=None, key_file=None, global_key=False, *args, **kwargs):
+    def __init__(
+        self,
+        id,
+        account,
+        key=None,
+        key_file=None,
+        global_key=False,
+        *args,
+        **kwargs,
+    ):
         self.log = getLogger('TransipProvider[{}]'.format(id))
         self.log.debug('__init__: id=%s, account=%s, token=***', id, account)
         super().__init__(id, *args, **kwargs)
 
         if key_file is not None:
-            self._client = TransIP(login=account, global_key=global_key, private_key_file=key_file)
+            self._client = TransIP(
+                login=account, global_key=global_key, private_key_file=key_file
+            )
         elif key is not None:
-            self._client = TransIP(login=account, global_key=global_key, private_key=key)
+            self._client = TransIP(
+                login=account, global_key=global_key, private_key=key
+            )
         else:
             raise TransipConfigException(
                 'Missing `key` or `key_file` parameter in config'

--- a/octodns_transip/__init__.py
+++ b/octodns_transip/__init__.py
@@ -80,15 +80,15 @@ class TransipProvider(BaseProvider):
     # See root NS handling in _process_desired_zone for more information
     ROOT_NS_TTL = 3600
 
-    def __init__(self, id, account, key=None, key_file=None, *args, **kwargs):
+    def __init__(self, id, account, key=None, key_file=None, global_key=False, *args, **kwargs):
         self.log = getLogger('TransipProvider[{}]'.format(id))
         self.log.debug('__init__: id=%s, account=%s, token=***', id, account)
         super().__init__(id, *args, **kwargs)
 
         if key_file is not None:
-            self._client = TransIP(login=account, private_key_file=key_file)
+            self._client = TransIP(login=account, global_key=global_key, private_key_file=key_file)
         elif key is not None:
-            self._client = TransIP(login=account, private_key=key)
+            self._client = TransIP(login=account, global_key=global_key, private_key=key)
         else:
             raise TransipConfigException(
                 'Missing `key` or `key_file` parameter in config'

--- a/tests/test_provider_octodns_transip.py
+++ b/tests/test_provider_octodns_transip.py
@@ -178,7 +178,9 @@ class TestTransipProvider(TestCase):
         # Those should work
         TransipProvider("test", "unittest", key=self.bogus_key)
         TransipProvider("test", "unittest", key_file="/fake/path")
-        TransipProvider("test", "unittest", key_file="/fake/path", global_key=True)
+        TransipProvider(
+            "test", "unittest", key_file="/fake/path", global_key=True
+        )
 
     @patch("octodns_transip.TransIP", make_failing_mock(401))
     def test_populate_unauthenticated(self):

--- a/tests/test_provider_octodns_transip.py
+++ b/tests/test_provider_octodns_transip.py
@@ -178,7 +178,7 @@ class TestTransipProvider(TestCase):
         # Those should work
         TransipProvider("test", "unittest", key=self.bogus_key)
         TransipProvider("test", "unittest", key_file="/fake/path")
-        TransipProvider("test", "unittest", key_file="/fake/path")
+        TransipProvider("test", "unittest", key_file="/fake/path", global_key=True)
 
     @patch("octodns_transip.TransIP", make_failing_mock(401))
     def test_populate_unauthenticated(self):


### PR DESCRIPTION
I use octodns with https://github.com/octodns/octodns-ddns because I have a residential connection where the IP sometimes changes.
TransIP has this feature which allows to only accept API requests from IPs from an allow list. In my scenario I have to turn off the allow list, since it will not work.
Currently this provider creates access tokens where the IP address needs to be on the allow list. With this change users can chose to disable this in order to have it work from any IP address.