### PR TITLE
Version 0.0.4 changelog update and release bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
-## v0.0.4 - 2024-??-?? - ???
+## v0.0.4 - 2025-04-04 - Key changes
 
 * Add global_key provider param to support disabling IP whitelisting
-
 
 ## v0.0.3 - 2024-11-29 - Delete w/o fail
 

--- a/octodns_transip/__init__.py
+++ b/octodns_transip/__init__.py
@@ -16,7 +16,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Record
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.3'
+__version__ = __VERSION__ = '0.0.4'
 
 DNSEntry = namedtuple('DNSEntry', ('name', 'expire', 'type', 'content'))
 


### PR DESCRIPTION
## v0.0.4 - 2025-04-04 - Key changes

* Add global_key provider param to support disabling IP whitelisting

/cc https://github.com/octodns/octodns-transip/pull/49#issuecomment-2778378488 @provokateurin 