### PR TITLE
Update hex comparison to be case insensitive in tests

### DIFF
--- a/.changelog/3b2b95b7381b480db675d9097f24100d.md
+++ b/.changelog/3b2b95b7381b480db675d9097f24100d.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Update hex comparison to be case insensitive in tests

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -181,11 +181,11 @@ tlsa:
   tll: 600
   type: 'TLSA'
   values:
-    - certificate_association_data: ABABABABABABABABAB
+    - certificate_association_data: ababababababababab
       certificate_usage: 1
       matching_type: 1
       selector: 1
-    - certificate_association_data: ABABABABABABABABAC
+    - certificate_association_data: ababababababababac
       certificate_usage: 2
       matching_type: 2
       selector: 0

--- a/tests/test_provider_octodns_transip.py
+++ b/tests/test_provider_octodns_transip.py
@@ -451,13 +451,13 @@ class TestTransipProvider(TestCase):
                 "name": "tlsa",
                 "expire": 3600,
                 "type": "TLSA",
-                "content": "1 1 1 ABABABABABABABABAB",
+                "content": "1 1 1 ababababababababab",
             },
             {
                 "name": "tlsa",
                 "expire": 3600,
                 "type": "TLSA",
-                "content": "2 0 2 ABABABABABABABABAC",
+                "content": "2 0 2 ababababababababac",
             },
             {
                 "name": "txt",


### PR DESCRIPTION
Updating hex handling in core to work with lowercase as that appears to be the norm for dns. Tests here need to ignore case so that they work before & after.

/cc https://github.com/octodns/octodns/pull/1389