### PR TITLE
Explicit non-escaped semicolons for YamlProvider

### DIFF
--- a/.changelog/e5797043392d465a8bd09d8a0c99ebd2.md
+++ b/.changelog/e5797043392d465a8bd09d8a0c99ebd2.md
@@ -1,0 +1,4 @@
+---
+type: none
+---
+Explicit non-escaped semicolons for YamlProvider

--- a/tests/config/unit.tests.yaml
+++ b/tests/config/unit.tests.yaml
@@ -195,7 +195,7 @@ txt:
   values:
     - Bah bah black sheep
     - have you any wool.
-    - 'v=DKIM1\;k=rsa\;s=email\;h=sha256\;p=A/kinda+of/long/string+with+numb3rs'
+    - 'v=DKIM1;k=rsa;s=email;h=sha256;p=A/kinda+of/long/string+with+numb3rs'
 urlfwd:
   ttl: 300
   type: URLFWD

--- a/tests/test_provider_octodns_transip.py
+++ b/tests/test_provider_octodns_transip.py
@@ -32,7 +32,9 @@ from octodns_transip import (
 
 def make_expected():
     expected = Zone("unit.tests.", [])
-    source = YamlProvider("test", join(dirname(__file__), "config"))
+    source = YamlProvider(
+        "test", join(dirname(__file__), "config"), escaped_semicolons=False
+    )
     source.populate(expected)
     return expected
 


### PR DESCRIPTION
YamlProvider is going to default to escaped_semicolons=False in 2.x, until then we'll explicitly ask for it to get tests happy w/o the deprecated warning.

/cc https://github.com/octodns/octodns/pull/1419